### PR TITLE
HTBHF-2498 Added missing app suffix.

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-- name: htbhf-production-stub
+- name: htbhf-production-stub((app-suffix))
   buildpacks:
   - java_buildpack
   health-check-type: http


### PR DESCRIPTION
Without an app suffix variable place holder, the deployment scripts deploy an application called `htbhf-production-stub` instead of `htbhf-production-stub-green`, which is what the smoke tests are expecting.